### PR TITLE
fix: Remove ID token if access token cannot be refreshed

### DIFF
--- a/src/Exception/TokenInvalidException.php
+++ b/src/Exception/TokenInvalidException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TRSTD\COT\Exception;
+
+use Exception;
+use RuntimeException;
+
+final class TokenInvalidException extends RuntimeException
+{
+    /**
+     * TokenInvalidException constructor.
+     *
+     * @param string $message The message to log
+     * @param int $code The error code
+     * @param Exception|null $previous The previous exception
+     */
+    public function __construct($message = 'Unexpected error', $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Relates #SW-161

## Description
Removes ID token if the session is expired and access token cannot be refreshed
